### PR TITLE
remove codesponsor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,5 +9,3 @@ Uses [boggle-roll](https://github.com/agarrharr/boggle-roll)
 ## License
 
 MIT
-
-<a href="https://app.codesponsor.io/link/3owRGftAkghuGdjHaa955zEJ/agarrharr/boggle" rel="nofollow"><img src="https://app.codesponsor.io/embed/3owRGftAkghuGdjHaa955zEJ/agarrharr/boggle.svg" style="width: 888px; height: 68px;" alt="Sponsor" /></a>


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8